### PR TITLE
Use require instead of eval in order to preserve normal Ruby semantics

### DIFF
--- a/lib/synvert/cli.rb
+++ b/lib/synvert/cli.rb
@@ -116,14 +116,14 @@ module Synvert
 
     # Load all rewriters.
     def load_rewriters
-      Dir.glob(File.join(default_snippets_path, 'lib/**/*.rb')).each { |file| eval(File.read(file)) }
+      Dir.glob(File.join(default_snippets_path, 'lib/**/*.rb')).each { |file| require file }
 
       @options[:custom_snippet_paths].each do |snippet_path|
         if snippet_path =~ /^http/
           uri = URI.parse snippet_path
           eval(uri.read)
         else
-          eval(File.read(snippet_path))
+          require snippet_path
         end
       end
     rescue


### PR DESCRIPTION
Eval'ing code that exists on the local filesystem skips a couple important pieces that require does. Require uses things like $GEM_HOME and $GEM_PATHS to source files in gems, both of which Bundler uses to expose things, and require adds important information to Ruby's internals that let debuggers like Byebug help you step through code. When possible, requiring files is better than eval, so use it when possible.